### PR TITLE
chore: Restructure workplace directory

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -120,5 +120,9 @@
 [rerere]
 	enabled = true
 
-[includeIf "gitdir:~/src/coop/"]
+[includeIf "gitdir:~/src/coopnorge/"]
   	path = ~/.gitconfig-coop
+
+[includeIf "gitdir:~/src/coop-scratchpad/"]
+  	path = ~/.gitconfig-coop
+


### PR DESCRIPTION
I'm changing my src directory structure to remove an additional layer for separating work repos and other repos. All of my work repos are on a predefined github organization, so it will be easier to just use those directly.
